### PR TITLE
types.h: added floating point number typedefs

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+
 typedef intptr_t isize;
 typedef uintptr_t usize;
 
@@ -11,3 +12,7 @@ typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;
 typedef int64_t i64;
+
+typedef float f32;
+typedef double f64;
+typedef long double f128;


### PR DESCRIPTION
added floating point typedefs for standard float sizes that would not give errors: 32, 64 and 128 bits. 
they seem like they are constant sizes given 32 bit and 64 bit architectures. 
could not see a way to get 80bit floats to be added.